### PR TITLE
Update v3 release with actual date in sem-ver-me.js

### DIFF
--- a/scripts/sem-ver-me.js
+++ b/scripts/sem-ver-me.js
@@ -8,8 +8,9 @@ CONFIG | set [Y, M, D] values with updateSpeed:
 - Patch version increments daily or every D days */
 
 /*======== Config ========*/
-const startDate = new Date("September 7, 2021");
-const startRelease = 1;  //Major version number corresponding to above date
+// const startDate = new Date("September 7, 2021");
+const startDate = new Date("February 4, 2024");
+const startRelease = 3;  //Major version number corresponding to above date
 const updateSpeed = [1, 1, 3];  //Larger numbers = slower updates
 
 


### PR DESCRIPTION
Projected release date for v3.0.0 had previously been September 7, 2023. After extensive testing, release of this major update was postponed until February 4, 2024. The current commit reflects this change delay to achieve higher accuracy for current and future scheduled releases.